### PR TITLE
記事一覧画面以外でタグを押下した時に、押下したタグで検索された記事一覧画面に遷移しないバグを解消

### DIFF
--- a/Vue/src/components/ArticleCard.vue
+++ b/Vue/src/components/ArticleCard.vue
@@ -150,6 +150,9 @@ export default {
   methods: {
     ...mapActions("articles", ["fetchArticles"]),
     findByTagId(tagId) {
+      if(this.$route.path !== '/article'){
+        this.$router.push({name: 'ArticleList'})
+      }
       this.searchCriteria.searchTag = [tagId];
       this.fetchArticles(this.searchCriteria);
     },


### PR DESCRIPTION
Closes #146 